### PR TITLE
Remove botocore and install requests directly

### DIFF
--- a/cfnresponse/__init__.py
+++ b/cfnresponse/__init__.py
@@ -5,11 +5,13 @@
 #  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 #  See the License for the specific language governing permissions and limitations under the License.
 
-from botocore.vendored import requests
 import json
+
+import requests
 
 SUCCESS = "SUCCESS"
 FAILED = "FAILED"
+
 
 def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
     responseUrl = event['ResponseURL']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cfnresponse",
-    version="1.0.1",
+    version="1.1.0",
     author="Amazon Web Services",
     description="Send a response object to a custom resource by way of an Amazon S3 presigned URL",
     long_description=long_description,
@@ -20,6 +20,6 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries :: Python Modules"
     ],
     install_requires=[
-        'botocore',
+        'requests>=2.22.0',
     ],
 )


### PR DESCRIPTION
Importing `requests` from `botocore` results in `DeprecationWarning` messages. `requests` has not been maintained as a vendored package within the module for some time and will be removed at some point in the future (it still exists only for compatibility purposes).

This PR switching the installation requirement away from `botocore` to `requests` and updated the code to import that module directly.

See: https://github.com/awslabs/aws-cloudformation-templates/issues/196