### PR TITLE
Update to v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ You can compare the code in `awslabs` with this pypi package with this command
 ```
 if [ "$(curl -s https://raw.githubusercontent.com/awslabs/aws-cloudformation-templates/master/aws/services/CloudFormation/MacrosExamples/StackMetrics/lambda/cfnresponse.py | sha256sum)" = "$(curl -s https://raw.githubusercontent.com/gene1wood/cfnresponse/master/cfnresponse/__init__.py | sha256sum)" ]; then echo "Files match"; fi
 ```
+
+The [`setup.py`](setup.py) for this module depends on a version of 
+[`botocore`](https://github.com/boto/botocore) prior to 
+[`1.13.0`](https://github.com/boto/botocore/releases/tag/1.13.0)
+when [`botocore.vendored.requests` was removed](https://github.com/boto/botocore/pull/1829)
+which would break `cfnresponse`.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cfnresponse",
-    version="1.0.1",
+    version="1.0.2",
     author="Amazon Web Services",
     description="Send a response object to a custom resource by way of an Amazon S3 presigned URL",
     long_description=long_description,
@@ -20,6 +20,6 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries :: Python Modules"
     ],
     install_requires=[
-        'botocore',
+        'botocore<1.13.0',  # https://github.com/boto/botocore/pull/1829
     ],
 )


### PR DESCRIPTION
This resolves the issue of botocore removing the vendored `requests` module
in botocore 1.13.0