### PR TITLE
Swap requests for urllib3

### DIFF
--- a/cfnresponse/__init__.py
+++ b/cfnresponse/__init__.py
@@ -5,9 +5,9 @@
 #  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 #  See the License for the specific language governing permissions and limitations under the License.
 
-from botocore.vendored import requests
+import urllib3
 import json
-
+http = urllib3.PoolManager()
 SUCCESS = "SUCCESS"
 FAILED = "FAILED"
 
@@ -36,9 +36,8 @@ def send(event, context, responseStatus, responseData, physicalResourceId=None, 
     }
 
     try:
-        response = requests.put(responseUrl,
-                                data=json_responseBody,
-                                headers=headers)
+        
+        response = http.request('PUT',responseUrl,body=json_responseBody.encode('utf-8'),headers=headers)
         print("Status code: " + response.reason)
     except Exception as e:
         print("send(..) failed executing requests.put(..): " + str(e))


### PR DESCRIPTION
This mirrors the AWS source repo exactly. botocore no longer includes vendored requests, but urllib3 is available to all lambdas. This is a super useful package on PyPi. This update will allow it to be used for many more years. 