### PR TITLE
Add support for custom reason

### DIFF
--- a/cfnresponse/__init__.py
+++ b/cfnresponse/__init__.py
@@ -7,14 +7,14 @@ http = urllib3.PoolManager()
 SUCCESS = "SUCCESS"
 FAILED = "FAILED"
 
-def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
+def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False, reason=None):
     responseUrl = event['ResponseURL']
 
     print(responseUrl)
 
     responseBody = {}
     responseBody['Status'] = responseStatus
-    responseBody['Reason'] = 'See the details in CloudWatch Log Stream: ' + context.log_stream_name
+    responseBody['Reason'] = reason or 'See the details in CloudWatch Log Stream: ' + context.log_stream_name
     responseBody['PhysicalResourceId'] = physicalResourceId or context.log_stream_name
     responseBody['StackId'] = event['StackId']
     responseBody['RequestId'] = event['RequestId']


### PR DESCRIPTION
AWS's documentation [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html) seems to diverge from what they provide in the `awslabs/aws-cloudformation-templates` repository. Being able to set a custom `Reason` in the CFN response is very useful for providing intuitive error messages back to end-users of the custom resource.

